### PR TITLE
Seperating NX/EX from set

### DIFF
--- a/src/lock-manager.js
+++ b/src/lock-manager.js
@@ -60,7 +60,8 @@ module.exports = (dispatcher, lockKey, tmpLockKey, retryPeriod = 2000) => {
             else if (success) redisClient.set(lockKey, instanceId, onGCLock);
             else acquireLockRetry(cb);
         };
-        redisClient.set(tmpLockKey, instanceId, 'NX', 'EX', 60, onGCTmpLock);
+        redisClient.setnx(tmpLockKey, instanceId, onGCTmpLock);
+        redisClient.expire(tmpLockKey, 60)
     }
 
     /**

--- a/src/monitor/stats.js
+++ b/src/monitor/stats.js
@@ -28,7 +28,7 @@ function stats(config) {
                 else cb();
             });
         } else {
-            client.set(rKeys.keyStatsFrontendLock, 1, 'EX', 10, 'NX', (err, success) => {
+            client.setnx(rKeys.keyStatsFrontendLock, 1, (err, success) => {
                 if (err) cb(err);
                 else {
                     lockAcquired = !!success;
@@ -40,6 +40,7 @@ function stats(config) {
                     }
                 }
             });
+            client.expire(rKeys.keyStatsFrontendLock, 10)
         }
     }
 


### PR DESCRIPTION
- Mutiple options in SET command are supported only in Redis >= 2.6.12
- Seperating NX, EX as client.setnx and client.expire