### PR TITLE
refactor: moved from node_redis to ioredis

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "koa": "2.2.0",
     "koa-send": "4.1.0",
     "koa-static": "3.0.0",
-    "redis": "2.7.1",
+    "ioredis": "4.14.0",
     "socket.io": "2.0.3",
     "uuid": "3.0.1"
   },

--- a/src/monitor/index.js
+++ b/src/monitor/index.js
@@ -4,7 +4,6 @@ const Socket = require('socket.io');
 const http = require('http');
 const Koa = require('koa');
 const send = require('koa-send');
-const redis = require('redis');
 const statsFn = require('./stats');
 const redisClient = require('../redis-client');
 const redisKeys = require('../redis-keys');

--- a/src/redis-client.js
+++ b/src/redis-client.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const redis = require('redis');
+const redis = require('ioredis');
 
 const clients = [];
 


### PR DESCRIPTION
Fixes https://github.com/weyoss/redis-smq/issues/5 by moving to `ioredis` instead of `node_redis`. All tests passing.

[![asciicast](https://asciinema.org/a/YdqxiNJKZg2aTK7CLY9jW1FAq.svg)](https://asciinema.org/a/YdqxiNJKZg2aTK7CLY9jW1FAq)