### PR TITLE
feat: allow queueName to be given as option

### DIFF
--- a/docs/api/consumer.md
+++ b/docs/api/consumer.md
@@ -88,6 +88,7 @@ Consumer([config[, options]])
   
 - `options.messageRetryDelay` *(Integer): Optional.* Message retry delay in seconds. By default message retry delay is 
 not set.
+- `options.queueName` *(String): Optional.* If unknown in advance, provide a queue name to consume for this consumer
 
 ### Consumer.prototype.run()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-smq",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "A simple high-performance Redis message queue for Node.js.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/consumer.js
+++ b/src/consumer.js
@@ -17,10 +17,10 @@ class Consumer extends Instance {
      */
     constructor(config = {}, options = {}) {
         super(config);
-        if (!this.constructor.hasOwnProperty('queueName')) {
+        if (!this.constructor.hasOwnProperty('queueName') && !options.queueName) {
             throw new Error('Undefined queue name!');
         }
-        this.setQueueName(this.constructor.queueName);
+        this.setQueueName(this.constructor.queueName || options.queueName);
         this.options = options;
         this.consumerMessageTTL = options.hasOwnProperty('messageTTL') ? Number(options.messageTTL) : 0;
         this.consumerMessageConsumeTimeout = options.hasOwnProperty('messageConsumeTimeout')

--- a/types/consumer.ts
+++ b/types/consumer.ts
@@ -7,6 +7,7 @@ export interface ConsumerConstructorOptionsInterface {
     messageTTL?: number,
     messageRetryThreshold?: number,
     messageRetryDelay?: number,
+    queueName?: string,
 }
 
 export interface ConsumerConstructorInterface {


### PR DESCRIPTION
# Description

Add a `queueName` option to the consumer constructor 

# Why

It let consumer be started on the fly.

One use case would be to start consumers from a main consumer.

ex: 

```ts

class MainConsumer extends Consumer {
 static queueName = 'main'

  consume(message, cb) {
    new GenericConsumer(config, { queueName: message}).run()
    cb()
  }
}

class GenericConsumer extends Consumer {
  consume(message, cb) {}
}
```

**NB**: happy to get help to implement tests :-)


