### PR TITLE
docs(redis-smq): update documentation references

### DIFF
--- a/packages/redis-smq/docs/api/classes/Consumer.md
+++ b/packages/redis-smq/docs/api/classes/Consumer.md
@@ -158,7 +158,7 @@ consumer.consume(
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/consuming-messages.md
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/consuming-messages.md
 
 ___
 

--- a/packages/redis-smq/docs/api/classes/ProducibleMessage.md
+++ b/packages/redis-smq/docs/api/classes/ProducibleMessage.md
@@ -84,7 +84,7 @@ will be processed based on its default settings, without considering its priorit
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setpriority
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setpriority
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 Retrieves the payload of a message.
 
-See https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setbody
+See https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setbody
 
 #### Returns
 
@@ -120,7 +120,7 @@ The consumption timeout value in milliseconds.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setconsumetimeout
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setconsumetimeout
 
 ___
 
@@ -162,9 +162,9 @@ The exchange associated with the message.
 
 **`See`**
 
- - https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setqueue
- - https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#settopic
- - https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setfanout
+ - https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setqueue
+ - https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#settopic
+ - https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setfanout
 
 ___
 
@@ -188,7 +188,7 @@ The fan-out pattern name as a string if one has been set,
 **`See`**
 
 For more information on setting the fan-out pattern:
-     https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setfanout
+     https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setfanout
 
 ___
 
@@ -212,7 +212,7 @@ The priority level of the message as defined
 **`See`**
 
 For more information on setting the priority:
-     https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setpriority
+     https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setpriority
 
 ___
 
@@ -236,7 +236,7 @@ The queue parameters associated with the message.
 **`See`**
 
 For more information on setting the queue parameters:
-     https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setqueue
+     https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setqueue
 
 ___
 
@@ -259,7 +259,7 @@ The retry delay value in milliseconds. A value of 0 indicates no delay
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setretrydelay
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setretrydelay
 
 ___
 
@@ -283,7 +283,7 @@ The retry threshold value. A positive integer representing the
 **`See`**
 
 For more information on setting the retry threshold:
-     https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setretrythreshold
+     https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setretrythreshold
 
 ___
 
@@ -307,7 +307,7 @@ The CRON expression as a string if one has been set,
 **`See`**
 
 For more information on setting the CRON schedule:
-     https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledcron
+     https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledcron
 
 ___
 
@@ -324,7 +324,7 @@ the message should be delayed before it is delivered to a queue.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduleddelay
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduleddelay
 
 ___
 
@@ -347,7 +347,7 @@ The number of times the message is scheduled to repeat.
 **`See`**
 
 For more information on setting the scheduled repeat:
-     https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledrepeat
+     https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledrepeat
 
 ___
 
@@ -370,7 +370,7 @@ The scheduled repeat period in milliseconds if set,
 **`See`**
 
 For more information on setting the scheduled repeat period:
-     https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledrepeatperiod
+     https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledrepeatperiod
 
 ___
 
@@ -394,7 +394,7 @@ The TTL value in milliseconds. A value of 0 indicates that the
 **`See`**
 
 For more information on setting the TTL:
-     https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setttl
+     https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setttl
 
 ___
 
@@ -418,7 +418,7 @@ The topic parameters associated with the message.
 **`See`**
 
 For more information on setting the topic parameters:
-     https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#settopic
+     https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#settopic
 
 ___
 
@@ -441,7 +441,7 @@ level has been set, and the method returns true. Otherwise, it returns false.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setpriority
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setpriority
 
 ___
 
@@ -463,10 +463,10 @@ The updated `ProducibleMessage` instance with the reset scheduled parameters.
 
 **`See`**
 
- - https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledcron
- - https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduleddelay
- - https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledrepeatperiod
- - https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledrepeat
+ - https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledcron
+ - https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduleddelay
+ - https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledrepeatperiod
+ - https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledrepeat
 
 ___
 
@@ -522,7 +522,7 @@ The default consumption timeout is 0, which means there is no timeout set.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setconsumetimeout
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setconsumetimeout
 
 ___
 
@@ -555,7 +555,7 @@ needing to duplicate the message for each queue.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/exchanges-and-delivery-models.md
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/exchanges-and-delivery-models.md
 
 ___
 
@@ -585,7 +585,7 @@ Otherwise, message priority does not take effect.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/queues.md
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/queues.md
 
 ___
 
@@ -611,7 +611,7 @@ by consumers interested in those messages.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/exchanges-and-delivery-models.md
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/exchanges-and-delivery-models.md
 
 ___
 
@@ -650,7 +650,7 @@ The default retry delay is 60000 milliseconds (1 minute).
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setretrydelay
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setretrydelay
 
 ___
 
@@ -680,7 +680,7 @@ The default retry threshold is 3.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setretrythreshold
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setretrythreshold
 
 ___
 
@@ -720,7 +720,7 @@ producibleMessage.setScheduledCRON('0 0 10 * * *').setScheduledRepeat(3).setSche
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledcron
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledcron
 
 ___
 
@@ -753,7 +753,7 @@ immediately, allowing for the system to perform any necessary operations or chec
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledelay
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledelay
 
 ___
 
@@ -839,7 +839,7 @@ the processing of outdated messages.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setttl
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setttl
 
 ___
 
@@ -869,7 +869,7 @@ their content or purpose.
 
 **`See`**
 
-https://github.com/weyoss/redis-smq/blob/master/docs/exchanges-and-delivery-models.md
+https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/exchanges-and-delivery-models.md
 
 ___
 

--- a/packages/redis-smq/docs/api/classes/Queue.md
+++ b/packages/redis-smq/docs/api/classes/Queue.md
@@ -131,8 +131,8 @@ Upon success the callback function is invoked with the created queue details.
 
 **`See`**
 
- - https://github.com/weyoss/redis-smq/blob/master/docs/api/enums/EQueueType.md
- - https://github.com/weyoss/redis-smq/blob/master/docs/api/enums/EQueueDeliveryModel.md
+ - https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/enums/EQueueType.md
+ - https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/enums/EQueueDeliveryModel.md
 
 ___
 

--- a/packages/redis-smq/docs/api/interfaces/IRedisSMQConfig.md
+++ b/packages/redis-smq/docs/api/interfaces/IRedisSMQConfig.md
@@ -48,4 +48,4 @@ ___
 
 **`See`**
 
-https://github.com/weyoss/redis-smq-common/blob/master/docs/api/README.md#iredisconfig
+https://github.com/weyoss/redis-smq-common/blob/master/packages/redis-smq/docs/api/README.md#iredisconfig

--- a/packages/redis-smq/docs/api/interfaces/IRedisSMQConfigRequired.md
+++ b/packages/redis-smq/docs/api/interfaces/IRedisSMQConfigRequired.md
@@ -76,7 +76,7 @@ ___
 
 **`See`**
 
-https://github.com/weyoss/redis-smq-common/blob/master/docs/api/README.md#iredisconfig
+https://github.com/weyoss/redis-smq-common/blob/master/packages/redis-smq/docs/api/README.md#iredisconfig
 
 #### Inherited from
 

--- a/packages/redis-smq/docs/redis-smq-architecture.md
+++ b/packages/redis-smq/docs/redis-smq-architecture.md
@@ -26,6 +26,6 @@ queuing and processing.
 
 &nbsp;
 
-![RedisSMQ Architecture Overview](/docs/redis-smq-architecture-overview.png)
+![RedisSMQ Architecture Overview](/packages/redis-smq/docs/redis-smq-architecture-overview.png)
 
 This structured workflow ensures efficient message handling, error management, and allows for seamless interactions between producers and consumers.

--- a/packages/redis-smq/src/config/types/config.ts
+++ b/packages/redis-smq/src/config/types/config.ts
@@ -16,7 +16,7 @@ import {
 
 export interface IRedisSMQConfig {
   /**
-   * @see https://github.com/weyoss/redis-smq-common/blob/master/docs/api/README.md#iredisconfig
+   * @see https://github.com/weyoss/redis-smq-common/blob/master/packages/redis-smq/docs/api/README.md#iredisconfig
    */
   redis?: IRedisConfig;
   namespace?: string;

--- a/packages/redis-smq/src/lib/consumer/consumer/consumer.ts
+++ b/packages/redis-smq/src/lib/consumer/consumer/consumer.ts
@@ -293,7 +293,7 @@ export class Consumer extends Runnable<TConsumerEvent> {
    * );
    * ```
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/consuming-messages.md
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/consuming-messages.md
    */
   consume(
     queue: TQueueExtendedParams,

--- a/packages/redis-smq/src/lib/message/producible-message.ts
+++ b/packages/redis-smq/src/lib/message/producible-message.ts
@@ -294,7 +294,7 @@ export class ProducibleMessage {
    *
    * @returns {ProducibleMessage} - The updated `ProducibleMessage` instance, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledelay
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledelay
    */
   setScheduledDelay(delay: number): ProducibleMessage {
     // JavaScript users do not have type checking
@@ -311,7 +311,7 @@ export class ProducibleMessage {
    * Retrieve the scheduled delay time for a message, which indicates how long
    * the message should be delayed before it is delivered to a queue.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduleddelay
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduleddelay
    */
   getScheduledDelay(): number | null {
     return this.scheduledDelay;
@@ -339,7 +339,7 @@ export class ProducibleMessage {
    *
    * @returns {ProducibleMessage} - Returns the instance of the ProducibleMessage class, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledcron
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledcron
    */
   setScheduledCRON(cron: string): ProducibleMessage {
     // it throws an exception for an invalid value
@@ -383,10 +383,10 @@ export class ProducibleMessage {
    *
    * @returns {ProducibleMessage} The updated `ProducibleMessage` instance with the reset scheduled parameters.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledcron
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduleddelay
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledrepeatperiod
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledrepeat
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledcron
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduleddelay
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledrepeatperiod
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledrepeat
    */
   resetScheduledParams(): ProducibleMessage {
     this.scheduledCron = null;
@@ -408,7 +408,7 @@ export class ProducibleMessage {
    *
    * @returns {ProducibleMessage} - The updated `ProducibleMessage` instance, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setttl
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setttl
    */
   setTTL(ttl: number): ProducibleMessage {
     this.ttl = ProducibleMessage.validateTTL(ttl);
@@ -429,7 +429,7 @@ export class ProducibleMessage {
    *
    * @returns {ProducibleMessage} - The updated `ProducibleMessage` instance, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setconsumetimeout
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setconsumetimeout
    */
   setConsumeTimeout(timeout: number): ProducibleMessage {
     this.consumeTimeout = ProducibleMessage.validateConsumeTimeout(timeout);
@@ -450,7 +450,7 @@ export class ProducibleMessage {
    *
    * @returns {ProducibleMessage} - The updated `ProducibleMessage` instance, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setretrythreshold
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setretrythreshold
    */
   setRetryThreshold(threshold: number): ProducibleMessage {
     this.retryThreshold = ProducibleMessage.validateRetryThreshold(threshold);
@@ -480,7 +480,7 @@ export class ProducibleMessage {
    *
    * @returns {ProducibleMessage} - The updated `ProducibleMessage` instance, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setretrydelay
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setretrydelay
    */
   setRetryDelay(delay: number): ProducibleMessage {
     this.retryDelay = ProducibleMessage.validateRetryDelay(delay);
@@ -518,7 +518,7 @@ export class ProducibleMessage {
    *
    * @returns {ProducibleMessage} - The updated `ProducibleMessage` instance, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/queues.md
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/queues.md
    */
   setPriority(priority: EMessagePriority): ProducibleMessage {
     this.priority = priority;
@@ -535,7 +535,7 @@ export class ProducibleMessage {
    * @returns {boolean} - Returns true if a priority level has been set for the message,
    *                      false otherwise.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setpriority
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setpriority
    */
   hasPriority(): boolean {
     return this.priority !== null;
@@ -550,7 +550,7 @@ export class ProducibleMessage {
    *
    * @returns {ProducibleMessage} - The updated `ProducibleMessage` instance, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setpriority
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setpriority
    */
   disablePriority(): ProducibleMessage {
     this.priority = null;
@@ -572,7 +572,7 @@ export class ProducibleMessage {
    * @param {string} fanOutName - The name of the fan-out pattern.
    * @returns {ProducibleMessage} - The updated `ProducibleMessage` instance, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/exchanges-and-delivery-models.md
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/exchanges-and-delivery-models.md
 
    */
   setFanOut(fanOutName: string): ProducibleMessage {
@@ -593,7 +593,7 @@ export class ProducibleMessage {
    * This feature is useful for organizing and filtering messages based on
    * their content or purpose.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/exchanges-and-delivery-models.md
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/exchanges-and-delivery-models.md
    * @param {string | ITopicParams} topicParams
    */
   setTopic(topicParams: string | ITopicParams): ProducibleMessage {
@@ -613,7 +613,7 @@ export class ProducibleMessage {
    *                                                  If an object is provided, it should contain the queue parameters as defined in the RedisSMQ documentation.
    * @returns {ProducibleMessage} - The updated `ProducibleMessage` instance, allowing method chaining.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/exchanges-and-delivery-models.md
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/exchanges-and-delivery-models.md
    */
   setQueue(queueParams: string | IQueueParams): ProducibleMessage {
     const exchange = _getExchangeDirectTransferable(queueParams);
@@ -633,7 +633,7 @@ export class ProducibleMessage {
    *          Returns null if no queue parameters have been set.
    *
    * @see For more information on setting the queue parameters:
-   *      https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setqueue
+   *      https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setqueue
    */
   getQueue(): IQueueParams | null {
     if (this.exchange && this.exchange.type === EExchangeType.DIRECT) {
@@ -653,7 +653,7 @@ export class ProducibleMessage {
    *          Returns null if no topic parameters have been set.
    *
    * @see For more information on setting the topic parameters:
-   *      https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#settopic
+   *      https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#settopic
    */
   getTopic(): ITopicParams | null {
     if (this.exchange && this.exchange.type === EExchangeType.TOPIC) {
@@ -673,7 +673,7 @@ export class ProducibleMessage {
    *                          or null if no fan-out pattern has been defined for this message.
    *
    * @see For more information on setting the fan-out pattern:
-   *      https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setfanout
+   *      https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setfanout
    */
   getFanOut(): string | null {
     if (this.exchange && this.exchange.type === EExchangeType.FANOUT) {
@@ -693,9 +693,9 @@ export class ProducibleMessage {
    *          Returns null if no exchange has been set.
    *          The returned object contains information about the exchange type and its parameters.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setqueue
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#settopic
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setfanout
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setqueue
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#settopic
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setfanout
    */
   getExchange(): TExchangeTransferable | null {
     if (this.exchange) {
@@ -714,7 +714,7 @@ export class ProducibleMessage {
    *                          or null if no repeat period has been defined for this message.
    *
    * @see For more information on setting the scheduled repeat period:
-   *      https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledrepeatperiod
+   *      https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledrepeatperiod
    */
   getScheduledRepeatPeriod(): number | null {
     return this.scheduledRepeatPeriod;
@@ -731,7 +731,7 @@ export class ProducibleMessage {
    *                          or null if no CRON schedule has been defined for this message.
    *
    * @see For more information on setting the CRON schedule:
-   *      https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledcron
+   *      https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledcron
    */
   getScheduledCRON(): string | null {
     return this.scheduledCron;
@@ -747,7 +747,7 @@ export class ProducibleMessage {
    *                   A value of 0 indicates the message is not scheduled for repetition.
    *
    * @see For more information on setting the scheduled repeat:
-   *      https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setscheduledrepeat
+   *      https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setscheduledrepeat
    */
   getScheduledRepeat(): number {
     return this.scheduledRepeat;
@@ -764,7 +764,7 @@ export class ProducibleMessage {
    *          message does not expire.
    *
    * @see For more information on setting the TTL:
-   *      https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setttl
+   *      https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setttl
    */
   getTTL(): number {
     return this.ttl;
@@ -781,7 +781,7 @@ export class ProducibleMessage {
    *          maximum number of retry attempts for the message.
    *
    * @see For more information on setting the retry threshold:
-   *      https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setretrythreshold
+   *      https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setretrythreshold
    */
   getRetryThreshold(): number {
     return this.retryThreshold;
@@ -797,7 +797,7 @@ export class ProducibleMessage {
    * @returns The retry delay value in milliseconds. A value of 0 indicates no delay
    *          between retry attempts.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setretrydelay
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setretrydelay
    */
   getRetryDelay(): number {
     return this.retryDelay;
@@ -812,7 +812,7 @@ export class ProducibleMessage {
    * @returns {number} The consumption timeout value in milliseconds.
    *                   A value of 0 indicates no timeout is set.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setconsumetimeout
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setconsumetimeout
    */
   getConsumeTimeout(): number {
     return this.consumeTimeout;
@@ -829,7 +829,7 @@ export class ProducibleMessage {
    *          in the EMessagePriority enum, or null if no priority has been set.
    *
    * @see For more information on setting the priority:
-   *      https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setpriority
+   *      https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setpriority
    */
   getPriority(): EMessagePriority | null {
     return this.priority;
@@ -838,7 +838,7 @@ export class ProducibleMessage {
   /**
    * Retrieves the payload of a message.
    *
-   * See https://github.com/weyoss/redis-smq/blob/master/docs/api/classes/ProducibleMessage.md#setbody
+   * See https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/classes/ProducibleMessage.md#setbody
    */
   getBody(): unknown {
     return this.body;

--- a/packages/redis-smq/src/lib/queue/queue.ts
+++ b/packages/redis-smq/src/lib/queue/queue.ts
@@ -59,8 +59,8 @@ export class Queue {
    * Save a new queue with specified parameters.
    * Upon success the callback function is invoked with the created queue details.
    *
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/enums/EQueueType.md
-   * @see https://github.com/weyoss/redis-smq/blob/master/docs/api/enums/EQueueDeliveryModel.md
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/enums/EQueueType.md
+   * @see https://github.com/weyoss/redis-smq/blob/master/packages/redis-smq/docs/api/enums/EQueueDeliveryModel.md
    * @param queue - The name or parameters for the queue.
    * @param queueType - The type of the queue, defined by EQueueType.
    * @param deliveryModel - The model for message delivery, defined by EQueueDeliveryModel.


### PR DESCRIPTION
# PR Summary
Small PR - Commit 8ef988862cedd84eddbd3e4eb5e2f50d575fe30f moved the docs to `packages/redis-smq/`. This PR adjusts sources to changes. Please note that this PR changes lot of files but all of them are trivial.