### PR TITLE
fix(redis-smq): propagate user redis config to Configuration in initialize

### DIFF
--- a/packages/redis-smq/src/redis-smq/lifecycle-manager.ts
+++ b/packages/redis-smq/src/redis-smq/lifecycle-manager.ts
@@ -47,7 +47,10 @@ export class LifecycleManager {
           RedisConnectionPool.initialize(redisConfig, {}, (err) => cb(err)),
         (cb) => {
           if (typeof redisSMQConfig === 'function')
-            return Configuration.initialize(cb);
+            return Configuration.initializeWithConfig(
+              { redis: redisConfig },
+              cb,
+            );
           Configuration.initializeWithConfig(redisSMQConfig, cb);
         },
         (cb) => InternalEventBus.getInstance().run(cb),


### PR DESCRIPTION
RedisSMQ.initialize(redisConfig, cb) passed the user's Redis config to the connection pool but not to Configuration, which fell back to defaultConfig (127.0.0.1:6379). This caused internal components (InternalEventBus, EventBus, BackgroundJobCluster) to create connections with the wrong client type, host, and port.

Replace Configuration.initialize(cb) with
Configuration.initializeWithConfig({ redis: redisConfig }, cb) so both initialization paths persist the Redis config into Configuration.

Fixes #141